### PR TITLE
Update project config to include symbol sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/*
 obj/*
+global.json
 
 example-project/bin/*
 example-project/obj/*

--- a/Logtail.csproj
+++ b/Logtail.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Logtail</PackageId>
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
     <Authors>Simon Rozsival, Tomas Hromada</Authors>
     <Company>Better Stack</Company>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
@@ -16,7 +16,12 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <DefaultItemExcludes>example-project\*</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);example-project/**</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 [![ISC License](https://img.shields.io/badge/license-ISC-ff69b4.svg)](LICENSE.md)
+[![Nuget version](https://badge.fury.io/nu/Logtail.svg")](https://www.nuget.org/packages/Logtail)
 
 Collect logs directly from your .NET applications.
 


### PR DESCRIPTION
https://trello.com/c/DSmWxhhC/1589-clientsnet-client-include-symbol-sources-push-client-as-release

Makes project buildable on Mac OS, respects default value of `DefaultItemExcludes` (see [docs](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#defaultitemexcludes)).

Ensures symbol sources are included when built as Release.
