### PR TITLE
Build .snupkg package, link public source codes, deterministic build

### DIFF
--- a/Logtail.csproj
+++ b/Logtail.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Logtail</PackageId>
-    <Version>0.2.3</Version>
+    <Version>0.2.4</Version>
     <Authors>Simon Rozsival, Tomas Hromada</Authors>
     <Company>Better Stack</Company>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
@@ -23,6 +23,19 @@
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
https://github.com/logtail/logtail-dotnet/pull/9 did not ensure source links are pushed along with built package. Inspired by https://stackoverflow.com/a/63984946

See also
- [Creating symbol packages (.snupkg) docs](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg)
- [C# Compiler Options that control code generation docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation)
- [Source Link docs](https://github.com/dotnet/sourcelink#source-link)