### PR TITLE
Configure layout="${message}" for the message to not include redundant data

### DIFF
--- a/example-project/README.md
+++ b/example-project/README.md
@@ -54,7 +54,7 @@ In the root directory of the project create the `nlog.config` file or copy the f
 	</extensions>
 
 	<targets>
-		<!-- Dont forget to change SOURCE_TOKEN to your actual cource token-->
+		<!-- Dont forget to change SOURCE_TOKEN to your actual source token-->
 		<target xsi:type="Logtail" name="logtail" layout="${message}" sourceToken="SOURCE_TOKEN" />
 	</targets>
 

--- a/example-project/README.md
+++ b/example-project/README.md
@@ -55,7 +55,7 @@ In the root directory of the project create the `nlog.config` file or copy the f
 
 	<targets>
 		<!-- Dont forget to change SOURCE_TOKEN to your actual cource token-->
-		<target xsi:type="Logtail" name="logtail" sourceToken="SOURCE_TOKEN" />
+		<target xsi:type="Logtail" name="logtail" layout="${message}" sourceToken="SOURCE_TOKEN" />
 	</targets>
 
 	<rules>
@@ -205,6 +205,7 @@ The Logtail target will send you logs periodically in batches to optimize networ
 <target
    xsi:type="Logtail"
    name="logtail"
+   layout="${message}"
    sourceToken="YOUR_SOURCE_TOKEN"
    maxBatchSize="200"
    flushPeriodMilliseconds="1000"

--- a/example-project/nlog.config
+++ b/example-project/nlog.config
@@ -10,7 +10,7 @@
 
 	<targets>
 		<!-- Dont forget to change SOURCE_TOKEN to your actual source token-->
-		<target xsi:type="Logtail" name="logtail" sourceToken="SOURCE_TOKEN" />
+		<target xsi:type="Logtail" name="logtail" layout="${message}" sourceToken="SOURCE_TOKEN" />
 	</targets>
 
 	<rules>

--- a/example-project/nlog.config
+++ b/example-project/nlog.config
@@ -9,7 +9,7 @@
 	</extensions>
 
 	<targets>
-		<!-- Dont forget to change SOURCE_TOKEN to your actual cource token-->
+		<!-- Dont forget to change SOURCE_TOKEN to your actual source token-->
 		<target xsi:type="Logtail" name="logtail" sourceToken="SOURCE_TOKEN" />
 	</targets>
 


### PR DESCRIPTION
https://trello.com/c/uy1h8IbP/3213-clientsdotnet-parse-message-nicely

Here's before and after as seen in Better Stack:
<img width="1235" alt="image" src="https://github.com/logtail/logtail-dotnet/assets/10008612/154309fd-ec7e-43bb-8d68-e4353e150dee">

---

TODO:
- [x] Update https://betterstack.com/docs/logs/net-c/