### PR TITLE
Add Logtail.NLog.ColorValueFormatter

### DIFF
--- a/Logtail.NLog/ColorValueFormatter.cs
+++ b/Logtail.NLog/ColorValueFormatter.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using NLog.Layouts;
+using NLog.MessageTemplates;
+
+namespace Logtail.NLog
+{
+    public class ColorValueFormatter : IValueFormatter
+    {
+        IValueFormatter valueFormatter;
+
+        private const string AnsiRed = "\x1b[31;1m";
+        private const string AnsiGreen = "\x1b[32;1m";
+        private const string AnsiYellow = "\x1b[33;1m";
+        private const string AnsiBlue = "\x1b[34;1m";
+        private const string AnsiCyan = "\x1b[36;1m";
+        private const string AnsiGray = "\x1b[37;1m";
+        private const string AnsiReset = "\x1b[0m";
+
+        public ColorValueFormatter(IValueFormatter valueFormatter = null)
+        {
+            this.valueFormatter = valueFormatter != null ? valueFormatter : ConfigurationItemFactory.Default.ValueFormatter;
+        }
+
+        public bool FormatValue(
+            Object value,
+            string format,
+            CaptureType captureType,
+            System.IFormatProvider formatProvider,
+            System.Text.StringBuilder builder
+        ) {
+            System.Text.StringBuilder innerBuilder = new System.Text.StringBuilder();
+
+            bool isSerializable = valueFormatter.FormatValue(value, format, captureType, formatProvider, innerBuilder);
+
+            if (innerBuilder.Length > 0) {
+                builder.Append(StartColor(value));
+                builder.Append(innerBuilder.ToString());
+                builder.Append(AnsiReset);
+            }
+
+            return isSerializable;
+        }
+
+        string StartColor(Object value) {
+            if (value is string || value is char) {
+                return AnsiCyan;
+            }
+            if (value is int || value is uint || value is long || value is ulong) {
+                return AnsiYellow;
+            }
+            if (value is bool boolValue) {
+                return boolValue ? AnsiGreen : AnsiRed;
+            }
+            if (value is null) {
+                return AnsiGray;
+            }
+
+            return AnsiBlue;
+        }
+    }
+}

--- a/Logtail.csproj
+++ b/Logtail.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Logtail</PackageId>
-    <Version>0.2.5</Version>
+    <Version>0.2.6</Version>
     <Authors>Simon Rozsival, Tomas Hromada</Authors>
     <Company>Better Stack</Company>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/example-project/DotNetLogtail.csproj
+++ b/example-project/DotNetLogtail.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Logtail" Version="0.2.5" />
+    <PackageReference Include="Logtail" Version="0.2.6" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.5" />
   </ItemGroup>
 

--- a/example-project/Program.cs
+++ b/example-project/Program.cs
@@ -7,6 +7,9 @@
 
 using NLog;
 
+// Configure NLog to color properties based on their type
+NLog.Config.ConfigurationItemFactory.Default.ValueFormatter = new Logtail.NLog.ColorValueFormatter();
+
 // Create logger for current class
 var logger = LogManager.GetCurrentClassLogger();
 

--- a/example-project/README.md
+++ b/example-project/README.md
@@ -93,6 +93,15 @@ var logger = LogManager.GetCurrentClassLogger();
 
 This will create a logger for the current class. In this case, it will be created for the `Program` class and it will add `“logger_string”` with the value `“Program”` to the context of the JSON log message.
 
+### Colored property values
+
+If you'd like your logged properties to be colored by their type, include following configuration when you create a logger:
+
+```csharp
+// Configure NLog to color properties based on their type
+NLog.Config.ConfigurationItemFactory.Default.ValueFormatter = new Logtail.NLog.ColorValueFormatter();
+```
+
 ### Filter logs
 
 The name of the logger will also be present in the log message which will look something like this:


### PR DESCRIPTION
https://trello.com/c/YnHSfjUV/3215-clientsdotnet-color-message-with-params-when-sent-to-better-stack

Optionally colors message parameters when sending to Better Stack:

<img width="1250" alt="image" src="https://github.com/logtail/logtail-dotnet/assets/10008612/3b652311-9ed8-4576-965d-ecf07f7bfb1b">

---

Unintentionally, the configuration is global - for all NLog targets - so if you add a target, it will also get colored values:

```diff
	<targets>
		<!-- Dont forget to change SOURCE_TOKEN to your actual source token-->
		<target xsi:type="Logtail" name="logtail" layout="${message}" sourceToken="SOURCE_TOKEN" />
+		<target xsi:type="Console" name="console" />
	</targets>

	<rules>
		<logger name="*" minlevel="Trace" writeTo="logtail" />
+		<logger name="*" minlevel="Trace" writeTo="console" />
	</rules>
```

<img width="997" alt="image" src="https://github.com/logtail/logtail-dotnet/assets/10008612/672ee071-c738-43b1-b6a7-4d4ccb72258f">


---

TODO:
- [x] Build and release `0.2.6`
- [x] Add to [docs article](https://betterstack.com/docs/logs/net-c/)